### PR TITLE
Integer Overflow in Max Heap Comparator for K Closest Points to Origin

### DIFF
--- a/patterns/java/TopKElements.java
+++ b/patterns/java/TopKElements.java
@@ -126,7 +126,9 @@ public class TopKElements {
 
     public int[][] kClosestPointsToOriginMaxHeapApproach(int[][] points, int k) {
         // Max heap with custom comparator to compare by distance
-        PriorityQueue<int[]> maxHeap = new PriorityQueue<>((a, b) -> getDistance(b) - getDistance(a));
+        PriorityQueue<int[]> maxHeap = new PriorityQueue<>(
+            (a, b) -> Integer.compare(getDistance(b), getDistance(a))
+        );
 
         // Iterate through all points
         for (int[] point : points) {


### PR DESCRIPTION
This change ensures that the distances are compared safely without the risk of overflow.
![image](https://github.com/user-attachments/assets/cf078a13-fa5b-429d-9f9b-1b29a8023b46)
