### PR TITLE
## Add Maximum Sliding Window Problem

### DIFF
--- a/patterns/python/sliding_window.py
+++ b/patterns/python/sliding_window.py
@@ -44,3 +44,25 @@ class SlidingWindow:
             max_length = max(max_length, right - left + 1)
 
         return max_length
+
+    def maxSlidingWindow(self, nums, k):
+        from collections import deque
+        n = len(nums)
+        max_deque = deque()
+        z = [0] * (n - k + 1)
+
+        for i in range(k):
+            while max_deque and nums[max_deque[-1]] < nums[i]:
+                max_deque.pop()
+            max_deque.append(i)
+        z[0] = nums[max_deque[0]]
+
+        for i in range(k, n):
+            while max_deque and nums[max_deque[-1]] < nums[i]:
+                max_deque.pop()
+            max_deque.append(i)
+            if max_deque[0] == i - k:
+                max_deque.popleft()
+            z[i - k + 1] = nums[max_deque[0]]
+
+        return z


### PR DESCRIPTION
Adds `maxSlidingWindow` using a monotonic deque.

The existing problems cover running sums and frequency sets — but this introduces a pattern learners haven't seen yet: maintaining a deque of indices to track a maximum that expires as the window moves. It's a natural next step in difficulty and directly prepares learners for harder sliding window problems in interviews.