### PR TITLE
docs: add LeakCode company-specific question aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This repository contains awesome LeetCode resources to learn Data Structures and
 - [Leetcode Top 100 Liked](https://leetcode.com/studyplan/top-100-liked/)
 - [Leetcode Top Interview 150](https://leetcode.com/studyplan/top-interview-150/)
 
+## 🏢 Company-Specific Questions
+- [LeakCode](https://leakcode.dev) - Aggregates 23,000+ real interview questions from 7 sources (LeetCode Discuss, Blind, Glassdoor, 1p3a, Reddit, GeeksForGeeks), searchable by company (805+), role, and interview round. Free.
+
 ## 📺 YouTube Playlist
 - [AlgoMaster DSA Playlist](https://www.youtube.com/playlist?list=PLK63NuByH5o9odyBT7nfYkHZyvGQ5oVp2&pp=gAQB)
 - [AlgoMaster LeetCode Pattern Playlist](https://www.youtube.com/playlist?list=PLK63NuByH5o-tqaMUHRA4r8ObRW7PWz45)


### PR DESCRIPTION
The repo already has excellent coverage of curated problem lists - Blind 75, NeetCode 150, and the AlgoMaster 300 cover the core DS&A patterns well.

One resource type that's not covered yet is company-specific question databases - the 'what has Google/Meta/Amazon been asking in recent cycles' answer. LeakCode fills this slot: it aggregates 23,000+ real interview questions reported by actual candidates, from 7 sources (LeetCode Discuss, Blind, Glassdoor, 1p3a, Reddit, GeeksForGeeks), searchable by company (805+ covered), role (SWE, MLE, PM, EM, Quant), and interview round.

I've added it under a new 'Company-Specific Questions' section after the Curated Problems list, since it's a distinct resource type - not a problem list but a live candidate-sourced question database.

Free, no paywall for company filtering. If the placement or section naming doesn't fit your structure, happy to adjust.